### PR TITLE
removed broken example projects link

### DIFF
--- a/website/getting-started.htm
+++ b/website/getting-started.htm
@@ -7,16 +7,6 @@
     <div id="intro-grid">
 
         <div>
-            <h2>example projects</h2>
-
-            <ul class="bars">
-                <li><a href="https://github.com/ZigEmbeddedGroup/getting-started-pico-zig">Getting started with Zig on
-                        the Raspberry Pi Pico
-                    </a></li>
-            </ul>
-        </div>
-
-        <div>
             <h2>microzig examples</h2>
 
             <ul class="bars">


### PR DESCRIPTION
link to [Getting started with Zig on the Raspberry Pi Pico](https://github.com/ZigEmbeddedGroup/getting-started-pico-zig) isn't available, removed broken link